### PR TITLE
Fix onclose callback

### DIFF
--- a/src/use-rave-payment.ts
+++ b/src/use-rave-payment.ts
@@ -59,7 +59,7 @@ export default function useRavePayment(
         payment_plan,
         hosted_payment,
         campaign_id,
-        onClose: onClose ? onClose : (): void => {},
+        onclose: onClose ? onClose : (): void => {},
         callback: onSuccess ? onSuccess : (): void => {},
       };
       // @ts-ignore


### PR DESCRIPTION
Hi there. Thanks for this package. 

The onclose callback doesn't fire. I believe it's because Flutterwaves function is lowercased. See here: https://developer.flutterwave.com/docs/rave-checkout-parameters